### PR TITLE
CI: drop support for Ubuntu 22.04

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -8,7 +8,7 @@ on:
 jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       actions: read
       checks: read

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -11,7 +11,6 @@ jobs:
     strategy:
       matrix:
         os:
-          - ubuntu-22.04
           - ubuntu-latest
           - ubuntu-24.04-arm
           - macos-14


### PR DESCRIPTION
[Homebrew 6.0 requires glibc >= 2.39](https://brew.sh/2026/06/11/homebrew-6.0.0/) which moves Ubuntu 22.04 to Support tier 2.